### PR TITLE
Fixes deprecation notices in Symfony 2.8

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -9,13 +9,13 @@ parameters:
 services:
     magento:
         class: %magento.factory.class%
-        arguments: [%magento.remote_adapter.class%, @event_dispatcher, @magento.logger]
+        arguments: [%magento.remote_adapter.class%, '@event_dispatcher', '@magento.logger']
         calls:
-            - [ setContainer,[ @service_container ] ]
+            - [ setContainer,[ '@service_container' ] ]
 
     magento.data_collector:
         class: %magento.collector.class%
-        arguments: [@magento.logger]
+        arguments: ['@magento.logger']
         tags:
             - { name: data_collector, template: %magento.profiler.template%, id: "magento" }
 


### PR DESCRIPTION
Not quoting the scalar starting with "@" is deprecated since Symfony 2.8 and will throw a ParseException in 3.0.